### PR TITLE
shift hypertabs to use visability: hidden, instead of display: none

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -9,10 +9,14 @@ E = element. a specific part of the component
 M = modifier. something that changes an element (or block)
 */
 
-var u = require('./util')
+var u = require('./util'),
+  each = u.each,
+  isVisible = u.isVisible,
+  setVisible = u.setVisible,
+  setInvisible = u.setInvisible
+
 var Menu = require('./menu')
 
-var each = u.each
 module.exports = function (onSelect) {
 
   var d
@@ -21,7 +25,7 @@ module.exports = function (onSelect) {
   function getSelection () {
     var sel = []
     each(content.children, function (tab, i) {
-      if(tab.style.display !== 'none')
+      if(isVisible(tab))
         sel.push(i)
     })
     if(''+sel === ''+selection) return
@@ -33,12 +37,15 @@ module.exports = function (onSelect) {
   var menu = Menu(content, function () {
     getSelection()
   })
-  var d = h('div.hypertabs.column',  menu, h('div.column', content))
+  var d = h('div.hypertabs.column',  [
+    menu,
+    h('div.column', content)
+  ])
 
   var selection = d.selected = []
 
   d.add = function (tab, change, split) {
-    if(!split) tab.style.display = 'none'
+    if(!split) setInvisible(tab)
     var index = content.children.length
     content.appendChild(tab)
     if(change !== false && !split) d.select(index)
@@ -73,7 +80,7 @@ module.exports = function (onSelect) {
       content.children[index].style.display = 'flex'
     else
       [].forEach.call(content.children, function (tab, i) {
-        tab.style.display = i == index ? 'flex' : 'none'
+        i == index ? setVisible(tab) : setInvisible(tab)
       })
     getSelection()
   }
@@ -101,9 +108,4 @@ module.exports = function (onSelect) {
 
   return d
 }
-
-
-
-
-
 

--- a/menu.js
+++ b/menu.js
@@ -1,31 +1,29 @@
 var h = require('hyperscript')
 var u = require('./util')
-var each = u.each
-var find = u.find
-
-function displayable (el) {
-  return el.style.display !== 'none'
-}
+  each = u.each,
+  find = u.find,
+  isVisible = u.isVisible,
+  setVisible = u.setVisible,
+  setInvisible = u.setInvisible
 
 function toggle_focus(el) {
-  if(el.style.display === 'none')
-    focus(el)
-  else
-    blur(el)
+  isVisible(el)
+    ? blur(el)
+    : focus(el)
 }
 
 function focus(el) {
-  if(el.style.display !== 'flex') {
-    el.style.display = 'flex'
-    el.dispatchEvent(new CustomEvent('focus', {target: el}))
-  }
+  if (isVisible(el)) return
+
+  setVisible(el)
+  el.dispatchEvent(new CustomEvent('focus', {target: el}))
 }
 
 function blur (el) {
-  if(el.style.display !== 'none') {
-    el.style.display = 'none'
-    el.dispatchEvent(new CustomEvent('blur', {target: el}))
-  }
+  if (!isVisible(el)) return
+
+  setInvisible(el)
+  el.dispatchEvent(new CustomEvent('blur', {target: el}))
 }
 
 function moveTo(el, list, i) {
@@ -59,7 +57,7 @@ module.exports = function (list, onSelect) {
     var wrap = h('div.hypertabs__tab.row.shrink', link, rm)
 
     function isSelected () {
-      if(displayable(el))
+      if(isVisible(el))
         wrap.classList.add('hypertabs--selected')
       else
         wrap.classList.remove('hypertabs--selected')

--- a/util.js
+++ b/util.js
@@ -1,13 +1,36 @@
 
-exports.each = function each(list, iter) {
+module.exports = {
+  each: each,
+  find: find,
+  isVisible: isVisible,
+  setVisible: setVisible,
+  setInvisible: setInvisible
+}
+
+function each(list, iter) {
   for(var i = 0; i < list.length; i++)
     iter(list[i], i, list)
 }
 
-exports.find = function find(list, test) {
+function find(list, test) {
   for(var i = 0; i < list.length; i++)
     if(test(list[i], i, list)) return i
 
   return -1
+}
+
+function isVisible(el) {
+  return el.style.visibility !== 'hidden'
+}
+
+function setVisible(el) {
+  el.style.visibility = 'visible'
+  el.style.position = 'inherit'
+}
+
+
+function setInvisible(el) {
+  el.style.visibility = 'hidden'
+  el.style.position = 'absolute'
 }
 


### PR DESCRIPTION
@dominictarr this shifter hypertabs to use the `visibility` style instead of `display`.

The primary motivation for this is that while `hidden` elements cannot be seen, they can still be measured. This is needed for a change I'm proposed to `pull-scroll`, which I've built in concert with this.