### PR TITLE
fix the position loss problem!

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
+  "maintainers": [
+    "mixmix"
+  ],
   "license": "MIT"
 }

--- a/util.js
+++ b/util.js
@@ -23,14 +23,19 @@ function isVisible(el) {
   return el.style.visibility !== 'hidden'
 }
 
+function setInvisible(el) {
+  //store scroll position in data-attribute
+  el.dataset.scrollTop = el.scrollTop
+
+  el.style.visibility = 'hidden'
+  el.style.position = 'absolute'
+}
+
 function setVisible(el) {
   el.style.visibility = 'visible'
   el.style.position = 'inherit'
-}
 
-
-function setInvisible(el) {
-  el.style.visibility = 'hidden'
-  el.style.position = 'absolute'
+  // restore scroll position from data-attribute
+  el.scrollTop = el.dataset.scrollTop 
 }
 


### PR DESCRIPTION
woo! 

turns out `position: abosulute` helps a hidden component not push other components around, **but** wipes the position.

This stores and restores position.
Have smoke-tested in patchbay and happily working (with hopefully no other side-effects)

---

note I tried squashing width to 0, but this returns the original problem (not enough content on hidden tabs to generate a scroll-bar and enable scroller). 

Summary of problem to date for those interested. Solution (as `pull-scroll` is currently written) requires : 
- knowledge of the hidden tabs content height (height = areaOfContent / width)
  - this precludes `display: none`, which collapses content size to 0
- must not take up actual space in layout
  - `visibility: hidden` items take up space still!
  - `position: absolute` wipes scroll position ... 