### PR TITLE
skip store of position if tab is already hidden

### DIFF
--- a/util.js
+++ b/util.js
@@ -24,6 +24,8 @@ function isVisible(el) {
 }
 
 function setInvisible(el) {
+  if (el.style.visibility === 'hidden') return 
+
   //store scroll position in data-attribute
   el.dataset.scrollTop = el.scrollTop
 


### PR DESCRIPTION
position recall was working, but only if you were going to tab and back.

This is because `setInvisible` is being called on all already invisible tabs (during tab selection). I've taught `setInvisible` to early return if a tab is invisible already 