### PR TITLE
add a hook for tab onClose

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,37 @@ setTimeout(
 When you call add, this creates a new tab, and it creates a page which contains the element you've provided.
 By default hypertabs assumes that the page size will be fixed and any scrolling will be done on the element you've provided (this is important if you care about preserving scroll position jumping between tabs).
 
+## API
+
+### `Tabs(opts)`
+
+Instantiates a tabs setup. `opts` is an optional _object_ which can contain any of the following keys:
+
+- `onSelect` - a callback function that is called when a tab is selected (called with ...)
+- `onClose` - a callback function that is called when a tab is closed (called with the page element being closed)
+- `prepend` - an html element which is prepended before your tabs in the 'tab nav'
+- `append` - an html element which is appended after your tabs in the 'tab nav'
+
+### `tab#add(page)`
+
+Adds a new page and makes an associated tab for it
+
+
+### `tab#remove`
+
+### `tab#has`
+
+### `tab#get`
+
+### `tab#select`
+
+### `tab#selectRelative`
+
+### `tab#fullscreen`
+
+### `tab#isFullscreen`
+
+
 ## Notifications
 
 Hypertabs wraps content you give it in a `div.page`.

--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ var u = require('./lib/util'),
 
 var Tabs = require('./tabs')
 
-module.exports = function (onSelect, opts) {
+module.exports = function (opts) {
   if (!opts) opts = {}
 
   var content = h('section.content')
-  var tabs = Tabs(content, function () { getSelection() })
+  var tabs = Tabs(content, function () { getSelection() }, opts.onClose)
   var d = h('div.Hypertabs', [
     h('nav', [
       opts.prepend,
@@ -29,7 +29,7 @@ module.exports = function (onSelect, opts) {
     })
     if(''+sel === ''+selection) return
     d.selected = selection = sel
-    if(onSelect) onSelect(selection)
+    if(opts.onSelect) opts.onSelect(selection)
     return sel
   }
 
@@ -94,7 +94,8 @@ module.exports = function (onSelect, opts) {
   d.remove = function (i) {
     if(Array.isArray(i)) return i.reverse().forEach(d.remove)
     var el = d.get(i)
-    if(el) content.removeChild(d.get(i))
+    opts.onClose && opts.onClose(el.firstChild)
+    if(el) content.removeChild(el)
   }
 
   var _display

--- a/tabs.js
+++ b/tabs.js
@@ -35,7 +35,7 @@ function moveTo(page, content, i) {
     content.insertBefore(page, content.children[i])
 }
 
-module.exports = function (content, onSelect) {
+module.exports = function (content, onSelect, onClose) {
   var tabs = h('section.tabs')
   var selection
 
@@ -43,6 +43,9 @@ module.exports = function (content, onSelect) {
     var link = h('a.link', {
       href: '#',
       onclick: function (ev) {
+        ev.preventDefault()
+        ev.stopPropagation()
+
         if(ev.shiftKey) toggle_focus(page)
         else {
           each(content.children, function (_page) {
@@ -50,16 +53,18 @@ module.exports = function (content, onSelect) {
             else blur(_page)
           })
         }
-        ev.preventDefault()
-        ev.stopPropagation()
       }},
       getTitle(page)
     )
     var rm = h('a.close', {
       href: '#',
       onclick: function (ev) {
+        ev.preventDefault()
+        ev.stopPropagation()
+
         page.parentNode.removeChild(page)
         tabs.removeChild(tab)
+        onClose && onClose(page.firstChild)
       }},
       'x'
     )


### PR DESCRIPTION
this is a breaking change for the API

You now instantiate tabs like `Tabs({ onSelected, onClose, prepend, append })`

I wanted an onClose as well as onSelected, so the choice was to make the API ugly or to change it a fair amount.
