### PR TITLE
close tab on middle click

### DIFF
--- a/tabs.js
+++ b/tabs.js
@@ -53,6 +53,16 @@ module.exports = function (content, onSelect, onClose) {
             else blur(_page)
           })
         }
+      },
+      onauxclick: function (ev) {
+        if(ev.which && ev.which === 2) {
+          ev.preventDefault()
+          ev.stopPropagation()
+
+          page.parentNode.removeChild(page)
+          tabs.removeChild(tab)
+          onClose && onClose(page.firstChild)
+        }
       }},
       getTitle(page)
     )


### PR DESCRIPTION
On electron, the middle click behavior on a tab is random (opens base.html on patchbay). 
This change would allow a user to close the tab on middle click, which is the default behavior on most tabbed browsers at-least.