### PR TITLE
add ability to over-ride tab onClick

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ By default hypertabs assumes that the page size will be fixed and any scrolling 
 
 Instantiates a tabs setup. `opts` is an optional _object_ which can contain any of the following keys:
 
-- `onSelect` - a callback function that is called when a tab is selected (called with ...)
-- `onClose` - a callback function that is called when a tab is closed (called with the page element being closed)
+- `onSelectHook` - a callback function that is called when a tab is selected (called with ...)
+- `onCloseHook` - a callback function that is called when a tab is closed (called with the page element being closed)
+- `onClick` - a callback function
 - `prepend` - an html element which is prepended before your tabs in the 'tab nav'
 - `append` - an html element which is appended after your tabs in the 'tab nav'
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ module.exports = function (opts) {
   if (!opts) opts = {}
 
   var content = h('section.content')
-  var tabs = Tabs(content, function () { getSelection() }, opts.onClose)
+  var tabs = Tabs(content, {
+    onClick: opts.onClick,
+    onSelect: function () { getSelection() },
+    onClose: opts.onClose
+  })
   var d = h('div.Hypertabs', [
     h('nav', [
       opts.prepend,

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (opts) {
 
   var content = h('section.content')
   var tabs = Tabs(content, {
-    onClick: opts.onClick,
+    onClickOverride: opts.onClickOverride,
     onSelect: function () { getSelection() },
     onClose: opts.onClose
   })

--- a/index.js
+++ b/index.js
@@ -12,9 +12,10 @@ module.exports = function (opts) {
 
   var content = h('section.content')
   var tabs = Tabs(content, {
-    onClickOverride: opts.onClickOverride,
-    onSelect: function () { getSelection() },
-    onClose: opts.onClose
+    onClickLink: opts.onClickLink,
+    onClickClose: opts.onClickClose,
+    onSelectHook: onSelectHook,
+    onCloseHook: opts.onCloseHook
   })
   var d = h('div.Hypertabs', [
     h('nav', [
@@ -25,7 +26,7 @@ module.exports = function (opts) {
     content
   ])
 
-  function getSelection () {
+  function onSelectHook () {
     var sel = []
     each(content.children, function (page, i) {
       if(isVisible(page))
@@ -33,8 +34,8 @@ module.exports = function (opts) {
     })
     if(''+sel === ''+selection) return
     d.selected = selection = sel
-    if(opts.onSelect) opts.onSelect(selection)
-    return sel
+
+    if(opts.onSelectHook) opts.onSelectHook(selection)
   }
 
   var selection = d.selected = []
@@ -47,7 +48,6 @@ module.exports = function (opts) {
     var index = content.children.length
     content.appendChild(page)
     if(change !== false && !split) d.select(index)
-    getSelection()
 
     return page
   }
@@ -87,22 +87,20 @@ module.exports = function (opts) {
       [].forEach.call(content.children, function (page, i) {
         i == index ? setVisible(page) : setInvisible(page)
       })
-    getSelection()
+    onSelectHook()
   }
 
   d.selectRelative = function (n) {
-    getSelection()
     d.select(selection[0] + n)
   }
 
   d.remove = function (i) {
     if(Array.isArray(i)) return i.reverse().forEach(d.remove)
     var el = d.get(i)
-    opts.onClose && opts.onClose(el.firstChild)
+    opts.onCloseHook && opts.onCloseHook(el.firstChild)
     if(el) content.removeChild(el)
   }
 
-  var _display
   d.fullscreen = function (full) {
     tabs.style.display = full ? 'none' : null
     return full
@@ -114,4 +112,3 @@ module.exports = function (opts) {
 
   return d
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "hypertabs",
+  "version": "5.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "browser-split": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
+      "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
+    },
+    "class-list": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
+      "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "html-element": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/html-element/-/html-element-1.3.0.tgz",
+      "integrity": "sha1-117LXa6HSx3mCgv4eUu9GYTQ8gk=",
+      "requires": {
+        "class-list": "0.1.1"
+      }
+    },
+    "hyperscript": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-1.4.7.tgz",
+      "integrity": "sha1-HyPYgPhDbKrCW5GnrDl0e4mnJhg=",
+      "requires": {
+        "browser-split": "0.0.0",
+        "class-list": "0.1.1",
+        "html-element": "1.3.0"
+      }
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "micro-css": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/micro-css/-/micro-css-1.0.0.tgz",
+      "integrity": "sha1-/7+beKMXOUmnVAC9ogaQUkMEKUo=",
+      "dev": true
+    }
+  }
+}

--- a/tabs.js
+++ b/tabs.js
@@ -50,8 +50,8 @@ module.exports = function (content, opts) {
     var link = h('a.link', {
       href: '#',
       onclick: function (ev) {
-        if (opts.onClick) {
-          opts.onClick(ev, page)
+        if (opts.onClickOverride) {
+          opts.onClickOverride(ev, page)
           return
         }
 

--- a/tabs.js
+++ b/tabs.js
@@ -1,10 +1,10 @@
 var h = require('hyperscript')
 var u = require('./lib/util')
-  each = u.each,
-  find = u.find,
-  isVisible = u.isVisible,
-  setVisible = u.setVisible,
-  setInvisible = u.setInvisible
+var each = u.each
+var find = u.find
+var isVisible = u.isVisible
+var setVisible = u.setVisible
+var setInvisible = u.setInvisible
 
 function toggle_focus(page) {
   isVisible(page)
@@ -35,7 +35,8 @@ function moveTo(page, content, i) {
     content.insertBefore(page, content.children[i])
 }
 
-module.exports = function (content, onSelect, onClose) {
+module.exports = function (content, opts) {
+  opts = opts || {}
   var tabs = h('section.tabs')
   var selection
 
@@ -43,12 +44,17 @@ module.exports = function (content, onSelect, onClose) {
     function close () {
       page.parentNode.removeChild(page)
       tabs.removeChild(tab)
-      onClose && onClose(page.firstChild)
+      opts.onClose && opts.onClose(page.firstChild)
     }
 
     var link = h('a.link', {
       href: '#',
       onclick: function (ev) {
+        if (opts.onClick) {
+          opts.onClick(ev, page)
+          return
+        }
+
         ev.preventDefault()
         ev.stopPropagation()
 
@@ -104,7 +110,7 @@ module.exports = function (content, onSelect, onClose) {
       if(page.title !== link.innerText)
         link.innerText = getTitle(page)
       updateTabClasses()
-      onSelect && onSelect()
+      opts.onSelect && opts.onSelect()
     }).observe(page, {attributes: true, attributeFilter: ['title', 'style', 'class']})
 
     updateTabClasses()


### PR DESCRIPTION
**Type:** Feature.

**Problem:** In Patchbat, the app tabs state is currently split over the history store and tabs. I'm trying to move to a more reactive architecture where action lead to changes in the history store, which lead to changes in the tabs. To do this nicely, I need to be able to take control of the tabs onClick.

**Solution:** add another opt to make it possible to over-ride the onClick