### PR TITLE
fix observation of page title mutation

### DIFF
--- a/tabs.js
+++ b/tabs.js
@@ -101,11 +101,14 @@ module.exports = function (content, onSelect, onClose) {
     }
 
     new MutationObserver(function (changes) {
-      if(page.title !== link.innerText)
-        link.innerText = getTitle(page)
+      if(getTitle(page) !== link.innerText) link.innerText = getTitle(page)
       updateTabClasses()
       onSelect && onSelect()
     }).observe(page, {attributes: true, attributeFilter: ['title', 'style', 'class']})
+
+    new MutationObserver(function (changes) {
+      if(getTitle(page) !== link.innerText) link.innerText = getTitle(page)
+    }).observe(page.firstChild, {attributes: true, attributeFilter: ['title']})
 
     updateTabClasses()
     tab.page = page


### PR DESCRIPTION
Type: Patch

Problem: I previously introduced a bug into hypertabs where I added another level of wrapping to pages when they were added. This then had the MutationObserver watching for `title` changes on the wrapper instead of the content.

Solultion: add a MutationObserver which targets the right thing 